### PR TITLE
Incorrect Gobber ingot IDs corrected.

### DIFF
--- a/src/main/resources/data/c/tags/items/gobber_end_ingots.json
+++ b/src/main/resources/data/c/tags/items/gobber_end_ingots.json
@@ -2,7 +2,7 @@
   "replace": false,
   "values": [
     {
-      "id": "gobber2:gobber_ingot_end",
+      "id": "gobber2:gobber2_ingot_end",
       "required": false
     }
   ]

--- a/src/main/resources/data/c/tags/items/gobber_ingot.json
+++ b/src/main/resources/data/c/tags/items/gobber_ingot.json
@@ -2,7 +2,7 @@
   "replace": false,
   "values": [
     {
-      "id": "gobber2:gobber_ingot",
+      "id": "gobber2:gobber2_ingot",
       "required": false
     }
   ]

--- a/src/main/resources/data/c/tags/items/gobber_nether_ingots.json
+++ b/src/main/resources/data/c/tags/items/gobber_nether_ingots.json
@@ -2,7 +2,7 @@
   "replace": false,
   "values": [
     {
-      "id": "gobber2:gobber_ingot_nether",
+      "id": "gobber2:gobber2_ingot_nether",
       "required": false
     }
   ]


### PR DESCRIPTION
Resulted in the end shield being craftable with only wooden planks (i.e. gobber end ingot missing from the recipe).